### PR TITLE
[Feature] Move GDAX to CoinbasePro

### DIFF
--- a/CryptoArbitrageSharp/ArbitrageClient.cs
+++ b/CryptoArbitrageSharp/ArbitrageClient.cs
@@ -5,8 +5,8 @@ using CryptoArbitrageSharp.Exchanges.Binance;
 using CryptoArbitrageSharp.Exchanges.Bitfinex;
 using CryptoArbitrageSharp.Exchanges.Bitstamp;
 using CryptoArbitrageSharp.Exchanges.Bittrex;
+using CryptoArbitrageSharp.Exchanges.CoinbasePro;
 using CryptoArbitrageSharp.Exchanges.CoinExchange;
-using CryptoArbitrageSharp.Exchanges.GDAX;
 using CryptoArbitrageSharp.Exchanges.Poloniex;
 
 namespace CryptoArbitrageSharp
@@ -27,7 +27,7 @@ namespace CryptoArbitrageSharp
             var currencyPairService = new CurrencyPairService();
 
             var bittrexExchange = new BittrexExchange(httpClient, httpRequestMessageService, currencyPairService);
-            var gdaxExchange = new GdaxExchange(httpClient, httpRequestMessageService, currencyPairService);
+            var gdaxExchange = new CoinbaseProExchange(httpClient, httpRequestMessageService, currencyPairService);
             var coinExchangeExchange = new CoinExchangeExchange(httpClient, httpRequestMessageService, currencyPairService);
             var krakenExchange = new CoinExchangeExchange(httpClient, httpRequestMessageService, currencyPairService);
             var poloniexExchange = new PoloniexExchange(httpClient, httpRequestMessageService, currencyPairService);

--- a/CryptoArbitrageSharp/CurrencyPair.cs
+++ b/CryptoArbitrageSharp/CurrencyPair.cs
@@ -1,4 +1,4 @@
-﻿namespace CryptoArbitrageSharp.Exchanges
+﻿namespace CryptoArbitrageSharp
 {
     public enum CurrencyPair
     {

--- a/CryptoArbitrageSharp/Exchange.cs
+++ b/CryptoArbitrageSharp/Exchange.cs
@@ -2,7 +2,7 @@
 {
     public class Exchange
     {
-        public static readonly Exchange Gdax = new Exchange("GDAX");
+        public static readonly Exchange CoinbasePro = new Exchange("CoinbasePro");
 
         public static readonly Exchange CoinExchange = new Exchange("CoinExchange");
 

--- a/CryptoArbitrageSharp/Exchanges/CoinbasePro/CoinbaseProExchange.cs
+++ b/CryptoArbitrageSharp/Exchanges/CoinbasePro/CoinbaseProExchange.cs
@@ -1,14 +1,14 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using CryptoArbitrageSharp.Exchanges.GDAX.Models;
+using CryptoArbitrageSharp.Exchanges.CoinbasePro.Models;
 
-namespace CryptoArbitrageSharp.Exchanges.GDAX
+namespace CryptoArbitrageSharp.Exchanges.CoinbasePro
 {
-    public class GdaxExchange : AbstractExchange
+    public class CoinbaseProExchange : AbstractExchange
     {
         private readonly ICurrencyPairService currencyPairService;
 
-        public GdaxExchange(
+        public CoinbaseProExchange(
             IHttpClient httpClient,
             IHttpRequestMessageService httpRequestMessageService,
             ICurrencyPairService currencyPairService)
@@ -19,13 +19,13 @@ namespace CryptoArbitrageSharp.Exchanges.GDAX
 
         public override async Task<BestExchangeQuote> Get(CurrencyPair currencyPair)
         {
-            var pair = currencyPairService.GetCurrencyPair(Exchange.Gdax, currencyPair);
-            var orderBook = await GetOrderBook<OrderBook>(ExchangeEndpointBase.Gdax + $"products/{pair}/book");
+            var pair = currencyPairService.GetCurrencyPair(Exchange.CoinbasePro, currencyPair);
+            var orderBook = await GetOrderBook<OrderBook>(ExchangeEndpointBase.CoinbasePro + $"products/{pair}/book");
 
             var bestBid = orderBook.Bids.First().First();
             var bestAsk = orderBook.Asks.First().First();
 
-            return new BestExchangeQuote(Exchange.Gdax.Name, bestBid, bestAsk);
+            return new BestExchangeQuote(Exchange.CoinbasePro.Name, bestBid, bestAsk);
         }
     }
 }

--- a/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/Ask.cs
+++ b/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/Ask.cs
@@ -1,8 +1,8 @@
-﻿namespace CryptoArbitrageSharp.Exchanges.GDAX.Models
+﻿namespace CryptoArbitrageSharp.Exchanges.CoinbasePro.Models
 {
-    public class Bid : Quote
+    public class Ask : Quote
     {
-        public Bid(
+        public Ask(
             decimal price,
             decimal size)
                 : base(price, size)

--- a/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/Bid.cs
+++ b/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/Bid.cs
@@ -1,8 +1,8 @@
-﻿namespace CryptoArbitrageSharp.Exchanges.GDAX.Models
+﻿namespace CryptoArbitrageSharp.Exchanges.CoinbasePro.Models
 {
-    public class Ask : Quote
+    public class Bid : Quote
     {
-        public Ask(
+        public Bid(
             decimal price,
             decimal size)
                 : base(price, size)

--- a/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/OrderBook.cs
+++ b/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/OrderBook.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace CryptoArbitrageSharp.Exchanges.GDAX.Models
+namespace CryptoArbitrageSharp.Exchanges.CoinbasePro.Models
 {
     public class OrderBook
     {

--- a/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/Quote.cs
+++ b/CryptoArbitrageSharp/Exchanges/CoinbasePro/Models/Quote.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CryptoArbitrageSharp.Exchanges.GDAX.Models
+namespace CryptoArbitrageSharp.Exchanges.CoinbasePro.Models
 {
     public class Quote
     {

--- a/CryptoArbitrageSharp/Exchanges/CurrencyPairService.cs
+++ b/CryptoArbitrageSharp/Exchanges/CurrencyPairService.cs
@@ -38,7 +38,7 @@ namespace CryptoArbitrageSharp.Exchanges
                         (CurrencyPair.LtcBtc, "18")
                     }
                 },
-                { Exchange.Gdax, new []
+                { Exchange.CoinbasePro, new []
                     {
                         (CurrencyPair.LtcBtc, "LTC-BTC")
                     }

--- a/CryptoArbitrageSharp/Exchanges/ExchangeEndpointBase.cs
+++ b/CryptoArbitrageSharp/Exchanges/ExchangeEndpointBase.cs
@@ -12,7 +12,7 @@
 
         public const string CoinExchange = "https://www.coinexchange.io/api/v1/";
 
-        public const string Gdax = "https://api.gdax.com/";
+        public const string CoinbasePro = "https://api.pro.coinbase.com/";
 
         public const string Kraken = "https://api.kraken.com/0/";
 


### PR DESCRIPTION
GDAX is going away on December 1, Switching to use coinbasepro endpoints